### PR TITLE
Use container labels for volume-tide-mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,6 @@ Salvage offers two ways of resolving the volume name:
 * `compose project scope`: The volume name is the same as the name of the volume in the compose project (resolved via docker compose labels on volume).
 * `global scope`: If volume name is prefixed with `g:` it will be resolved by the given name.
 
-### Mapping global volumes
-
-This approach is used when a volume is not managed by compose.
-
-#### Mapping compose volumes
-
-Imagine you have a volume section in a `docker-compose.yml` like so the following `my-volume`.
-```yaml
-volumes:
-  - my-volume
-```
-
 ### Container configuration
 
 The following labels can be used on containers and will define how Salvage will tell the container to stop modifying the backup volume.

--- a/README.md
+++ b/README.md
@@ -118,3 +118,13 @@ If you think that's a good idea go ahead and do it.
 
 No! salvage assumes to be the only instance running on a docker daemon.
 If you run multiple instances, they will start to interfere with each other.
+
+## Why not use volume labels to configure backup volumes?
+
+Docker does not allow to modify volume labels.
+This means in order to (re)configure a volume for backup, you need to remove the volume and recreate it, which also means losing all data that is currently stored in the volume.
+Backup configuration should not require risky volume operations.
+
+## Can I attach a volume to multiple Tides?
+
+This sounds like a horrible idea, but it is possible.

--- a/README.md
+++ b/README.md
@@ -64,15 +64,28 @@ The following labels are used to configure a crane and need to present on the sa
 * `salvage.cranes.<name>.env.<key>`: Environment variables to pass to the crane. For example `salvage.cranes.<name>.env.S3_BUCKET=my-bucket`.
 * `salvage.cranes.<name>.mount.<volume>`: Mounts a volume to the crane. The volume will be mounted at the specified path. For exmaples `salvage.cranes.<name>.mount.my-volume=/cache`.
 
-## Volume configuration
+### Volume configuration
 
 By default, Salvage will ignore all volumes it hasn't been explicitly instructed to backup.
 In order to configure a volume for backup, you need to label it as such.
-While executing a Tide, salvage will check for the following labels on each volume:
+Since changing labels on volumes is not supported by Docker, volumes are configured by attaching labels to containers instead (see FAQ).
+To do this, place the `salvage.tide.<name>=<volume1>,<volume2>,...` label on any container (it doesn't need to actually use the volume).
+Salvage offers two ways of resolving the volume name:
 
-* `salvage.tide`: The name of the Tide this volume is attached to.
-* `salvage.crane`: Override the default crane to use for this volume.
-* `salvage.dryRun`: If set to `true`, the volume will not be backed up, but all preparations will be done and a status message is logged instead.
+* `compose project scope`: The volume name is the same as the name of the volume in the compose project (resolved via docker compose labels on volume).
+* `global scope`: If volume name is prefixed with `g:` it will be resolved by the given name.
+
+### Mapping global volumes
+
+This approach is used when a volume is not managed by compose.
+
+#### Mapping compose volumes
+
+Imagine you have a volume section in a `docker-compose.yml` like so the following `my-volume`.
+```yaml
+volumes:
+  - my-volume
+```
 
 ### Container configuration
 

--- a/src/main/java/de/chrisliebaer/salvage/SalvageMain.java
+++ b/src/main/java/de/chrisliebaer/salvage/SalvageMain.java
@@ -4,41 +4,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
 import lombok.extern.log4j.Log4j2;
 
-/*
-Kommunikation mit crane über socket im container
-
-0. Nach Start eigene Umgebung erfassen
-1. Auf nächste Tide warten
-2. Volumes identifizieren, die von Tide gesichert werden müssen
-außerdem: individual, smart, project (steuert gruppierung)
-3b. Nachfolgende Aktionen für jede dieser Komponenten ausführen
-
-4. Checkpoint: Volumes befinden sich in Backup State
-5. crane config laden (wird über envvars in salvage konfiguriert)
-	* image name
-	* env vars
-	* volume mounts
-6. crane parellel auf alle volumes ausführen (parellel, wenn von crane erlaubt)
-6.a crane meldet status irgendwie zurück
-
-7. Container state wiederherstellen
-8. Tide complete
-
-Beispiel für mich:
-hetzner-borg-crane:
-- image chrisliebaer/crane-borg
-- keine Volumes
-- ENV: secret login
-
-daily-backup-tide:
-- 4 uhr nachts
-
-volumes:
-irgendwas
-- tide: daily-backups
-- crane: hetzner-borg-crane
- */
-
 @SuppressWarnings("CallToSystemExit")
 @Log4j2
 public enum SalvageMain {

--- a/src/main/java/de/chrisliebaer/salvage/SalvageService.java
+++ b/src/main/java/de/chrisliebaer/salvage/SalvageService.java
@@ -3,6 +3,7 @@ package de.chrisliebaer.salvage;
 import com.cronutils.model.time.ExecutionTime;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.InspectVolumeResponse;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
@@ -23,7 +24,9 @@ import org.apache.logging.log4j.ThreadContext;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -31,9 +34,11 @@ import java.util.stream.Collectors;
 public class SalvageService extends AbstractService {
 	
 	public static final String SALVAGE_ENTITY_LABEL = "salvage.entity";
+	public static final String COMPOSE_LABEL_PROJECT = "com.docker.compose.project";
+	private static final String COMPOSE_LABEL_VOLUME = "com.docker.compose.volume";
 	
 	private static final String ROOT_LABEL = "salvage.root";
-	private static final String LABEL_VOLUME_TIDE_NAME = "salvage.tide";
+	private static final String LABEL_CONTAINER_TIDE_MAP_PREFIX = "salvage.tide.";
 	
 	private SalvageConfiguration configuration;
 	private final Thread serviceThread = new Thread(this::serviceThreadEntry, "SalvageService");
@@ -141,11 +146,9 @@ public class SalvageService extends AbstractService {
 		try (var docker = createDefaultClient()) {
 			docker.pingCmd().exec();
 			
-			// identify volumes belonging to this tide
-			var volumes = docker.listVolumesCmd()
-					.withFilter("label", List.of(LABEL_VOLUME_TIDE_NAME + "=" + tide.name())).exec().getVolumes().stream()
-					.map(v -> SalvageVolume.fromInspectVolumeResponse(v, configuration.cranes()))
-					.collect(Collectors.toMap(SalvageVolume::name, v -> v));
+			// identifying volumes of tide is rather complicated and involes different logic, depending on wether the volume is part of a project or not
+			var volumes = getVolumeNamesForTide(docker, tide);
+			
 			
 			log.info("found {} volumes belonging to tide '{}'", volumes.size(), tide.name());
 			if (log.isDebugEnabled()) {
@@ -311,6 +314,56 @@ public class SalvageService extends AbstractService {
 		}
 	}
 	
+	private static Map<String, SalvageVolume> getVolumeNamesForTide(DockerClient docker, SalvageTide tide) {
+		var tideLabel = LABEL_CONTAINER_TIDE_MAP_PREFIX + tide.name();
+		var map = new HashMap<String, SalvageVolume>();
+		
+		// check for volumes that are mapped to tide via container labels
+		var containers = docker.listContainersCmd()
+				.withLabelFilter(List.of(tideLabel))
+				.withShowAll(true)
+				.exec();
+		
+		// resolve volume names in respect to container compose project
+		for (var container : containers) {
+			var labels = container.getLabels();
+			var volumeNames = labels.get(tideLabel).split(",");
+			log.trace("container '{}' is mapped to tide '{}' via labels: {}", container.getId(), tide.name(), volumeNames);
+			
+			var project = labels.get(COMPOSE_LABEL_PROJECT);
+			if (project == null) {
+				log.warn("container {} is not part of a project, only project containers can be used for volume mapping", container.getId());
+				continue;
+			}
+			
+			for (var volumeName : volumeNames) {
+				InspectVolumeResponse volume;
+				if (volumeName.startsWith("g:")) {
+					// perform global lookup using raw volume name
+					volumeName = volumeName.substring(2);
+					volume = docker.inspectVolumeCmd(volumeName).exec();
+				} else {
+					var volumes = docker.listVolumesCmd()
+							.withFilter("label", List.of(
+									COMPOSE_LABEL_PROJECT + ":" + project,
+									COMPOSE_LABEL_VOLUME + ":" + volumeName
+							))
+							.withDanglingFilter(true) // true will fetch ALL volumes
+							.exec().getVolumes();
+					
+					if (volumes.size() != 1) {
+						throw new IllegalArgumentException("expected exactly one volume in project '" + project + "' named '" + volumeName + "' but found " + volumes.size());
+					}
+					
+					volume = volumes.get(0);
+				}
+				
+				map.put(volume.getName(), SalvageVolume.fromInspectVolumeResponse(volume));
+			}
+		}
+		return map;
+	}
+	
 	/**
 	 * Calls docker API to get own container ID.
 	 *
@@ -318,7 +371,7 @@ public class SalvageService extends AbstractService {
 	 * @return The container id of the container this application is currently running in.
 	 * @throws IllegalStateException If fetching the container id failed.
 	 */
-	public static String getOwnContainerId(DockerClient docker) {
+	private static String getOwnContainerId(DockerClient docker) {
 		
 		// we also check of stopped container since there is no situation where these are a good idea
 		var containers = docker.listContainersCmd()

--- a/src/main/java/de/chrisliebaer/salvage/SalvageVessel.java
+++ b/src/main/java/de/chrisliebaer/salvage/SalvageVessel.java
@@ -82,6 +82,7 @@ public class SalvageVessel {
 		log.debug("created container '{}' for crane '{}' to backup volume '{}'", container.getId(), crane, volume);
 		
 		try {
+			// TODO remove autoremove and simple remove container by hand, will get rid of many bugs
 			startBackupContainer(container);
 		} catch (Throwable e) {
 			// at this point container has been created but might not have been auto removed, so we try to remove it in an attempt to clean up

--- a/src/main/java/de/chrisliebaer/salvage/SalvageVessel.java
+++ b/src/main/java/de/chrisliebaer/salvage/SalvageVessel.java
@@ -119,7 +119,7 @@ public class SalvageVessel {
 				.withFollowStream(true)
 				.exec(new FrameCallback(frame -> {
 					var line = new String(frame.getPayload(), StandardCharsets.UTF_8).trim();
-					log.debug("[{}}@{}] {}", volume.name(), crane.name(), line);
+					log.debug("[{}@{}] {}", volume.name(), crane.name(), line);
 				}));
 		log.trace("starting backup container '{}' for volume '{}'", container.getId(), volume.name());
 		docker.startContainerCmd(container.getId()).exec();

--- a/src/main/java/de/chrisliebaer/salvage/entity/SalvageContainer.java
+++ b/src/main/java/de/chrisliebaer/salvage/entity/SalvageContainer.java
@@ -1,6 +1,7 @@
 package de.chrisliebaer.salvage.entity;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import de.chrisliebaer.salvage.SalvageService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -9,8 +10,6 @@ import java.util.Optional;
 
 public record SalvageContainer(String id, Optional<String> project, List<SalvageVolume> volumes,
 							   ContainerAction action, Optional<ContainerCommand> commandPre, Optional<ContainerCommand> commandPost) {
-	
-	public static final String COMPOSE_LABEL_PROJECT = "com.docker.compose.project";
 	
 	private static final String LABEL_CONTAINER_ACTION = "salvage.action";
 	
@@ -52,7 +51,7 @@ public record SalvageContainer(String id, Optional<String> project, List<Salvage
 		var labels = container.getConfig().getLabels();
 		
 		// container might be part of compose project
-		var project = Optional.ofNullable(labels.get(COMPOSE_LABEL_PROJECT));
+		var project = Optional.ofNullable(labels.get(SalvageService.COMPOSE_LABEL_PROJECT));
 		
 		// parse user or fall back to container user
 		var user = labels.getOrDefault(LABEL_CONTAINER_COMMAND_USER, container.getConfig().getUser());

--- a/src/main/java/de/chrisliebaer/salvage/entity/SalvageVolume.java
+++ b/src/main/java/de/chrisliebaer/salvage/entity/SalvageVolume.java
@@ -2,20 +2,14 @@ package de.chrisliebaer.salvage.entity;
 
 import com.github.dockerjava.api.command.InspectVolumeResponse;
 
-import java.util.Map;
-import java.util.Optional;
-
-public record SalvageVolume(String name, Optional<SalvageCrane> crane, boolean dryRun, BackupMeta.VolumeMeta meta) {
+public record SalvageVolume(String name, BackupMeta.VolumeMeta meta) {
 	
 	private static final String LABEL_VOLUME_TIDE_NAME = "salvage.tide";
-	private static final String LABEL_VOLUME_TIDE_DRY_RUN = "salvage.dryRun";
 	
-	public static SalvageVolume fromInspectVolumeResponse(InspectVolumeResponse volume, Map<String, SalvageCrane> cranes) {
+	public static SalvageVolume fromInspectVolumeResponse(InspectVolumeResponse volume) {
 		var name = volume.getName();
-		var crane = cranes.get(volume.getLabels().get(LABEL_VOLUME_TIDE_NAME));
-		var dryRun = Boolean.parseBoolean(volume.getLabels().get(LABEL_VOLUME_TIDE_DRY_RUN));
 		var meta = BackupMeta.VolumeMeta.fromVolumeInspect(volume);
 		
-		return new SalvageVolume(name, Optional.ofNullable(crane), dryRun, meta);
+		return new SalvageVolume(name, meta);
 	}
 }


### PR DESCRIPTION
Using volume labels sounds like a good idea in theory, but since you can not change them after having created the volume, they are basically useless for configuring a backup. Instead, we are now using container labels to tag compose volumes to their tide.